### PR TITLE
Add post-processing of layers to the tile server

### DIFF
--- a/tileserver/__init__.py
+++ b/tileserver/__init__.py
@@ -85,10 +85,11 @@ class TileServer(object):
     # we want this during development, but not during production
     propagate_errors = False
 
-    def __init__(self, layer_config, data_fetcher, io_pool, store,
-                 redis_cache_index, health_checker=None):
+    def __init__(self, layer_config, data_fetcher, post_process_data,
+                 io_pool, store, redis_cache_index, health_checker=None):
         self.layer_config = layer_config
         self.data_fetcher = data_fetcher
+        self.post_process_data = post_process_data
         self.io_pool = io_pool
         self.store = store
         self.redis_cache_index = redis_cache_index
@@ -131,6 +132,7 @@ class TileServer(object):
         formatted_tiles = process_coord(
             coord,
             feature_data['feature_layers'],
+            self.post_process_data,
             [format],
             feature_data['unpadded_bounds'],
             feature_data['padded_bounds'],
@@ -247,7 +249,7 @@ def create_tileserver_from_config(config):
 
     with open(queries_config_path) as query_cfg_fp:
         queries_config = yaml.load(query_cfg_fp)
-    all_layer_data, layer_data = parse_layer_data(
+    all_layer_data, layer_data, post_process_data = parse_layer_data(
         queries_config, template_path, reload_templates)
     all_layer_names = [x['name'] for x in all_layer_data]
     layer_config = LayerConfig(all_layer_names, layer_data)
@@ -284,8 +286,8 @@ def create_tileserver_from_config(config):
         health_checker = HealthChecker(health_check_url, conn_info)
 
     tile_server = TileServer(
-        layer_config, data_fetcher, io_pool, store, redis_cache_index,
-        health_checker)
+        layer_config, data_fetcher, post_process_data, io_pool, store,
+        redis_cache_index, health_checker)
     return tile_server
 
 


### PR DESCRIPTION
This change corresponds to https://github.com/mapzen/tilequeue/pull/22 for the tilequeue and allows the server to post-process layers to, for example, "intercut" layers to try and solve https://github.com/mapzen/vector-datasource/issues/136.
