### PR TITLE
allow multithreaded requests

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -13,3 +13,4 @@ server:
   port: 8080
   debug: true
   reload: true
+  threaded: true


### PR DESCRIPTION
The server uses a single thread by default and tends to choke when under constant pressure to server multiple tiles. This change allows it to scale over multiple cpu cores, by serving each request in a new thread. 
