### PR TITLE
Updates to match tilequeue buffer-bounds changes

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -9,6 +9,7 @@ queries:
   template-path: ../vector-datasource/queries
   reload-templates: true
 formats: [json, topojson, mvt]
+buffer: {}
 server:
   host: localhost
   port: 8080


### PR DESCRIPTION
Connects to https://github.com/mapzen/vector-datasource/issues/106

Assuming the tilequeue changes look good in https://github.com/mapzen/tilequeue/pull/92 , this pr contains the corresponding updates to tileserver.

@zerebubuth could you review please?
