### PR TITLE
Switch to using ujson, remove simplejson from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ PyYAML==3.11
 redis==2.10.5
 requests==2.10.0
 Shapely==1.4.3
-simplejson==3.6.4
 six==1.10.0
 StreetNames==0.1.5
+ujson==1.3.5
 Werkzeug==0.9.6
 wsgiref==0.1.2
 zope.dottedname==4.1.0

--- a/tileserver/__init__.py
+++ b/tileserver/__init__.py
@@ -19,7 +19,7 @@ from tilequeue.utils import format_stacktrace_one_line
 from tilequeue.metatile import make_single_metatile, extract_metatile
 from werkzeug.wrappers import Request
 from werkzeug.wrappers import Response
-import json
+import ujson as json
 import psycopg2
 import random
 import shapely.geometry


### PR DESCRIPTION
Related to https://github.com/tilezen/tilequeue/pull/143 and https://github.com/tilezen/tilequeue/issues/139.

Switch to using `ujson`, a faster JSON library, when loading the JSON tile to rebuild into a different format.