### PR TITLE
Fix typo in ujson version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ requests==2.10.0
 Shapely==1.4.3
 six==1.10.0
 StreetNames==0.1.5
-ujson==1.3.5
+ujson==1.35
 Werkzeug==0.9.6
 wsgiref==0.1.2
 zope.dottedname==4.1.0


### PR DESCRIPTION
Thanks to @v-andr for pointing this out - looks like we missed a typo in the `requirements.txt` file. Ooops!
