### PR TITLE
Fix to match tilequeue's change of signature for formatting a tile.

### DIFF
--- a/tileserver/__init__.py
+++ b/tileserver/__init__.py
@@ -163,7 +163,7 @@ def reformat_selected_layers(
         meters_per_pixel_dim, buffer_cfg)
 
     tile_data_file = StringIO()
-    format.format_tile(tile_data_file, feature_layers, coord,
+    format.format_tile(tile_data_file, feature_layers, coord.zoom,
                        bounds_merc, bounds_lnglat)
     tile_data = tile_data_file.getvalue()
     return tile_data


### PR DESCRIPTION
Changed from taking a coordinate to just taking a zoom level integer.