### PR TITLE
Add maximum "interesting" zoom

### DIFF
--- a/tileserver/__init__.py
+++ b/tileserver/__init__.py
@@ -283,7 +283,7 @@ class TileServer(object):
         # update the tiles of interest set with the coordinate
         if self.redis_cache_index and interesting_tile:
             self.io_pool.apply_async(async_update_tiles_of_interest,
-                                     (self.redis_cache_index, coord))
+                                     (self.redis_cache_index, meta_coord))
 
         if self.using_metatiles():
             # make all formats when making metatiles


### PR DESCRIPTION
Beyond this zoom, tileserver will generate a tile but not store it or add it to the TOI. This avoids us having to "prune" z17 out of the TOI all the time.