### PR TITLE
Remove Redis TOI stuff

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -44,8 +44,3 @@ health:
 # store:
 #   type: directory
 #   name: tiles
-
-# additionally, `redis` and `queue` configuration blocks may be
-# optionally specified as well. See the tilequeue sample config for
-# details. These are used to manage the tiles of interest and offline
-# processing queues.

--- a/tileserver/__init__.py
+++ b/tileserver/__init__.py
@@ -190,7 +190,7 @@ class TileServer(object):
     propagate_errors = False
 
     def __init__(self, layer_config, extensions, data_fetcher,
-                 post_process_data, io_pool, store, redis_cache_index,
+                 post_process_data, io_pool, store,
                  buffer_cfg, formats, health_checker=None,
                  add_cors_headers=False, metatile_size=None,
                  metatile_store_originals=False, path_tile_size=None,
@@ -201,7 +201,6 @@ class TileServer(object):
         self.post_process_data = post_process_data
         self.io_pool = io_pool
         self.store = store
-        self.redis_cache_index = redis_cache_index
         self.buffer_cfg = buffer_cfg
         self.formats = formats
         self.health_checker = health_checker
@@ -538,17 +537,6 @@ def create_tileserver_from_config(config):
         if store_type and store_name:
             store = make_store(store_type, store_name, store_config)
 
-    redis_cache_index = None
-    redis_config = config.get('redis')
-    if redis_config:
-        from redis import StrictRedis
-        from tilequeue.cache import RedisCacheIndex
-        redis_host = redis_config.get('host', 'localhost')
-        redis_port = redis_config.get('port', 6379)
-        redis_db = redis_config.get('db', 0)
-        redis_client = StrictRedis(redis_host, redis_port, redis_db)
-        redis_cache_index = RedisCacheIndex(redis_client)
-
     health_checker = None
     health_check_config = config.get('health')
     if health_check_config:
@@ -569,9 +557,9 @@ def create_tileserver_from_config(config):
 
     tile_server = TileServer(
         layer_config, extensions, data_fetcher, post_process_data, io_pool,
-        store, redis_cache_index, buffer_cfg, formats,
-        health_checker, add_cors_headers, metatile_size,
-        metatile_store_originals, path_tile_size, max_interesting_zoom)
+        store, buffer_cfg, formats, health_checker, add_cors_headers,
+        metatile_size, metatile_store_originals, path_tile_size,
+        max_interesting_zoom)
     return tile_server
 
 


### PR DESCRIPTION
@rmarianski pointed out a problem related to my Redis changes in #85. This should be a fix for that.

```
2017-05-02_15:59:43.19939 Traceback (most recent call last):
2017-05-02_15:59:43.19940   File "/usr/lib/python2.7/dist-packages/gunicorn/arbiter.py", line 473, in spawn_worker
2017-05-02_15:59:43.19940     worker.init_process()
2017-05-02_15:59:43.19940   File "/usr/lib/python2.7/dist-packages/gunicorn/workers/base.py", line 100, in init_process
2017-05-02_15:59:43.19941     self.wsgi = self.app.wsgi()
2017-05-02_15:59:43.19941   File "/usr/lib/python2.7/dist-packages/gunicorn/app/base.py", line 115, in wsgi
2017-05-02_15:59:43.19941     self.callable = self.load()
2017-05-02_15:59:43.19942   File "/usr/lib/python2.7/dist-packages/gunicorn/app/wsgiapp.py", line 33, in load
2017-05-02_15:59:43.19942     return util.import_app(self.app_uri)
2017-05-02_15:59:43.19942   File "/usr/lib/python2.7/dist-packages/gunicorn/util.py", line 373, in import_app
2017-05-02_15:59:43.19943     app = eval(obj, mod.__dict__)
2017-05-02_15:59:43.19943   File "<string>", line 1, in <module>
2017-05-02_15:59:43.19944   File "/usr/local/lib/python2.7/dist-packages/tileserver/__init__.py", line 582, in wsgi_server
2017-05-02_15:59:43.19944     tile_server = create_tileserver_from_config(config)
2017-05-02_15:59:43.19944   File "/usr/local/lib/python2.7/dist-packages/tileserver/__init__.py", line 545, in create_tileserver_from_config
2017-05-02_15:59:43.19945     from tilequeue.cache import RedisCacheIndex
2017-05-02_15:59:43.19945 ImportError: No module named cache
```