### PR TITLE
Add a caching backend with Redis- and File-backed caches

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -38,9 +38,11 @@ health:
   # request path to listen for health checks
   url: /_health
 
-# to cache tiles locally, enable a store. This can be useful when
-# experiencing timeouts for low or mid zoom ranges. See the tilequeue
-# sample config for details.
-# store:
-#   type: directory
-#   name: tiles
+# to cache tiles locally, enable a cache. This can be useful when
+# experiencing timeouts for low or mid zoom ranges.
+# cache:
+#   type: <redis|file|null, default 'null'>
+#   redis:
+#     url: redis://localhost:6379
+#   file:
+#     prefix: directory_prefix

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -57,6 +57,7 @@ class FileCacheTests(unittest.TestCase):
 
         # After releasing, obtaining the lock from "client A" should work
         c.obtain_lock(coord)
+        c.release_lock(coord)
 
     def test_set_get(self):
         import os

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,147 @@
+import unittest
+
+
+class CacheHelperTests(unittest.TestCase):
+    def test_clean_empty_parent_dirs(self):
+        import os
+        from tileserver.cache import clean_empty_parent_dirs, mkdir_p
+
+        mkdir_p('foo/bar/baz')
+        with open('foo/bar/baz/hello.txt', 'w') as f:
+            f.write('hello world')
+        clean_empty_parent_dirs('foo/bar/baz/hello.txt')
+        self.assertTrue(
+            os.path.exists('foo/bar/baz/hello.txt'),
+            "The directory is not empty, so it should not have been deleted")
+        os.remove('foo/bar/baz/hello.txt')
+
+        clean_empty_parent_dirs('foo/bar/baz', 'foo/bar')
+        self.assertTrue(
+            os.path.exists('foo/bar'),
+            "Shouldn't have deleted the parent_dir")
+
+        clean_empty_parent_dirs('foo/bar')
+        self.assertFalse(
+            os.path.exists('foo'),
+            "Should have deleted everything")
+
+
+class FileCacheTests(unittest.TestCase):
+    def test_obtain_lock(self):
+        from ModestMaps.Core import Coordinate
+        from tileserver.cache import FileCache
+
+        coord = Coordinate(0, 0, 0)
+
+        c = FileCache('foo')
+        try:
+            c.obtain_lock(coord)
+        finally:
+            c.release_lock(coord)
+
+    def test_obtain_lock_already_locked(self):
+        from ModestMaps.Core import Coordinate
+        from tileserver.cache import FileCache, LockTimeout
+
+        coord = Coordinate(0, 0, 0)
+
+        c = FileCache('foo')
+        try:
+            # Obtain a lock from "client A"
+            c.obtain_lock(coord)
+            with self.assertRaises(LockTimeout):
+                # Locking from "client B" should time out
+                c.obtain_lock(coord, timeout=1)
+        finally:
+            c.release_lock(coord)
+
+        # After releasing, obtaining the lock from "client A" should work
+        c.obtain_lock(coord)
+
+    def test_set_get(self):
+        import os
+        from ModestMaps.Core import Coordinate
+        from tileserver.cache import FileCache, clean_empty_parent_dirs
+        coord = Coordinate(0, 0, 0)
+        tile_data = 'hello world'
+
+        c = FileCache('foo')
+        c.set(coord, tile_data)
+        actual_data = c.get(coord)
+
+        self.assertEquals(tile_data, actual_data)
+
+        os.remove('foo/00/000/000/000/000/000/000.data')
+        clean_empty_parent_dirs('foo/00/000/000/000/000/000')
+
+
+class MockRedis(object):
+    def __init__(self):
+        self._data = {}
+
+    def set(self, key, data):
+        self._data[key] = data
+
+    def get(self, key):
+        return self._data.get(key)
+
+    def delete(self, key):
+        del self._data[key]
+
+    def setnx(self, key, data):
+        if key in self._data:
+            return False
+        else:
+            self.set(key, data)
+
+    def getset(self, key, data):
+        val = self._data.get(key)
+        self._data[key] = data
+        return val
+
+
+class RedisCacheTests(unittest.TestCase):
+    def setUp(self):
+        self.redis = MockRedis()
+
+    def test_obtain_lock(self):
+        from ModestMaps.Core import Coordinate
+        from tileserver.cache import RedisCache
+
+        coord = Coordinate(0, 0, 0)
+
+        c = RedisCache(self.redis)
+        try:
+            c.obtain_lock(coord)
+        finally:
+            c.release_lock(coord)
+
+    def test_obtain_lock_already_locked(self):
+        from ModestMaps.Core import Coordinate
+        from tileserver.cache import RedisCache, LockTimeout
+
+        coord = Coordinate(0, 0, 0)
+
+        c = RedisCache(self.redis)
+        try:
+            c.obtain_lock(coord)
+            with self.assertRaises(LockTimeout):
+                c.obtain_lock(coord, timeout=1)
+        finally:
+            c.release_lock(coord)
+
+        c.obtain_lock(coord)
+
+    def test_set_get(self):
+        from ModestMaps.Core import Coordinate
+        from tileserver.cache import RedisCache
+
+        coord = Coordinate(0, 0, 0)
+        tile_data = 'hello world'
+
+        c = RedisCache(self.redis)
+        c.set(coord, tile_data)
+        actual_data = c.get(coord)
+
+        self.assertEquals(tile_data, actual_data)
+        self.redis.delete(c.generate_key('data', coord))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -59,6 +59,23 @@ class FileCacheTests(unittest.TestCase):
         c.obtain_lock(coord)
         c.release_lock(coord)
 
+    def test_contextmanager_lock(self):
+        from ModestMaps.Core import Coordinate
+        from tileserver.cache import FileCache, LockTimeout
+
+        coord = Coordinate(0, 0, 0)
+        c = FileCache('foo')
+
+        # A plain 'ol lock should work without exception
+        with c.lock(coord):
+            pass
+
+        with c.lock(coord):
+            with self.assertRaises(LockTimeout):
+                # A second lock on the same coord should time out
+                with c.lock(coord, timeout=1):
+                    pass
+
     def test_set_get(self):
         import os
         from ModestMaps.Core import Coordinate
@@ -132,6 +149,23 @@ class RedisCacheTests(unittest.TestCase):
             c.release_lock(coord)
 
         c.obtain_lock(coord)
+
+    def test_contextmanager_lock(self):
+        from ModestMaps.Core import Coordinate
+        from tileserver.cache import RedisCache, LockTimeout
+
+        coord = Coordinate(0, 0, 0)
+        c = RedisCache(self.redis)
+
+        # A plain 'ol lock should work without exception
+        with c.lock(coord):
+            pass
+
+        with c.lock(coord):
+            with self.assertRaises(LockTimeout):
+                # A second lock on the same coord should time out
+                with c.lock(coord, timeout=1):
+                    pass
 
     def test_set_get(self):
         from ModestMaps.Core import Coordinate

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,6 +6,11 @@ class CacheHelperTests(unittest.TestCase):
         import os
         from tileserver.cache import clean_empty_parent_dirs, mkdir_p
 
+        self.assertFalse(
+            os.path.exists('foo'),
+            'The test expects foo/ to not exist when it starts'
+        )
+
         mkdir_p('foo/bar/baz')
         with open('foo/bar/baz/hello.txt', 'w') as f:
             f.write('hello world')
@@ -30,67 +35,79 @@ class FileCacheTests(unittest.TestCase):
     def test_obtain_lock(self):
         from ModestMaps.Core import Coordinate
         from tileserver.cache import FileCache
+        from tilequeue.format import lookup_format_by_extension
 
         coord = Coordinate(0, 0, 0)
+        fmt = lookup_format_by_extension('mvt')
 
         c = FileCache('foo')
         try:
-            c.obtain_lock(coord)
+            c.obtain_lock(coord, fmt)
         finally:
-            c.release_lock(coord)
+            c.release_lock(coord, fmt)
 
     def test_obtain_lock_already_locked(self):
         from ModestMaps.Core import Coordinate
         from tileserver.cache import FileCache, LockTimeout
+        from tilequeue.format import lookup_format_by_extension
 
         coord = Coordinate(0, 0, 0)
+        fmt = lookup_format_by_extension('mvt')
 
         c = FileCache('foo')
         try:
             # Obtain a lock from "client A"
-            c.obtain_lock(coord)
+            c.obtain_lock(coord, fmt)
             with self.assertRaises(LockTimeout):
                 # Locking from "client B" should time out
-                c.obtain_lock(coord, timeout=1)
+                c.obtain_lock(coord, fmt, timeout=1)
         finally:
-            c.release_lock(coord)
+            c.release_lock(coord, fmt)
 
         # After releasing, obtaining the lock from "client A" should work
-        c.obtain_lock(coord)
-        c.release_lock(coord)
+        c.obtain_lock(coord, fmt)
+        c.release_lock(coord, fmt)
 
     def test_contextmanager_lock(self):
         from ModestMaps.Core import Coordinate
         from tileserver.cache import FileCache, LockTimeout
+        from tilequeue.format import lookup_format_by_extension
 
         coord = Coordinate(0, 0, 0)
+        fmt = lookup_format_by_extension('mvt')
+
         c = FileCache('foo')
 
         # A plain 'ol lock should work without exception
-        with c.lock(coord):
+        with c.lock(coord, fmt):
             pass
 
-        with c.lock(coord):
+        with c.lock(coord, fmt):
             with self.assertRaises(LockTimeout):
                 # A second lock on the same coord should time out
-                with c.lock(coord, timeout=1):
+                with c.lock(coord, fmt, timeout=1):
                     pass
 
     def test_set_get(self):
         import os
         from ModestMaps.Core import Coordinate
         from tileserver.cache import FileCache, clean_empty_parent_dirs
+        from tilequeue.format import lookup_format_by_extension
+
         coord = Coordinate(0, 0, 0)
+        fmt = lookup_format_by_extension('mvt')
+
         tile_data = 'hello world'
 
         c = FileCache('foo')
-        c.set(coord, tile_data)
-        actual_data = c.get(coord)
+        c.set(coord, fmt, tile_data)
+        actual_data = c.get(coord, fmt)
 
         self.assertEquals(tile_data, actual_data)
 
-        os.remove('foo/00/000/000/000/000/000/000.data')
-        clean_empty_parent_dirs('foo/00/000/000/000/000/000')
+        key = c._generate_key('data', coord, fmt)
+        os.remove(key)
+        clean_empty_parent_dirs(os.path.dirname(key))
 
 
 class MockRedis(object):
@@ -125,58 +142,67 @@ class RedisCacheTests(unittest.TestCase):
     def test_obtain_lock(self):
         from ModestMaps.Core import Coordinate
         from tileserver.cache import RedisCache
+        from tilequeue.format import lookup_format_by_extension
 
         coord = Coordinate(0, 0, 0)
+        fmt = lookup_format_by_extension('mvt')
 
         c = RedisCache(self.redis)
         try:
-            c.obtain_lock(coord)
+            c.obtain_lock(coord, fmt)
         finally:
-            c.release_lock(coord)
+            c.release_lock(coord, fmt)
 
     def test_obtain_lock_already_locked(self):
         from ModestMaps.Core import Coordinate
         from tileserver.cache import RedisCache, LockTimeout
+        from tilequeue.format import lookup_format_by_extension
 
         coord = Coordinate(0, 0, 0)
+        fmt = lookup_format_by_extension('mvt')
 
         c = RedisCache(self.redis)
         try:
-            c.obtain_lock(coord)
+            c.obtain_lock(coord, fmt)
             with self.assertRaises(LockTimeout):
-                c.obtain_lock(coord, timeout=1)
+                c.obtain_lock(coord, fmt, timeout=1)
         finally:
-            c.release_lock(coord)
+            c.release_lock(coord, fmt)
 
-        c.obtain_lock(coord)
+        c.obtain_lock(coord, fmt)
 
     def test_contextmanager_lock(self):
         from ModestMaps.Core import Coordinate
         from tileserver.cache import RedisCache, LockTimeout
+        from tilequeue.format import lookup_format_by_extension
 
         coord = Coordinate(0, 0, 0)
+        fmt = lookup_format_by_extension('mvt')
+
         c = RedisCache(self.redis)
 
         # A plain 'ol lock should work without exception
-        with c.lock(coord):
+        with c.lock(coord, fmt):
             pass
 
-        with c.lock(coord):
+        with c.lock(coord, fmt):
             with self.assertRaises(LockTimeout):
                 # A second lock on the same coord should time out
-                with c.lock(coord, timeout=1):
+                with c.lock(coord, fmt, timeout=1):
                     pass
 
     def test_set_get(self):
         from ModestMaps.Core import Coordinate
         from tileserver.cache import RedisCache
+        from tilequeue.format import lookup_format_by_extension
 
         coord = Coordinate(0, 0, 0)
+        fmt = lookup_format_by_extension('mvt')
         tile_data = 'hello world'
 
         c = RedisCache(self.redis)
-        c.set(coord, tile_data)
-        actual_data = c.get(coord)
+        c.set(coord, fmt, tile_data)
+        actual_data = c.get(coord, fmt)
 
         self.assertEquals(tile_data, actual_data)
-        self.redis.delete(c.generate_key('data', coord))
+        self.redis.delete(c._generate_key('data', coord, fmt))

--- a/tileserver/__init__.py
+++ b/tileserver/__init__.py
@@ -268,8 +268,8 @@ class TileServer(object):
         coord = request_data.coord
         format = request_data.format
 
-        with self.cache.lock(coord):
-            tile_data = self.cache.get(coord)
+        with self.cache.lock(coord, format):
+            tile_data = self.cache.get(coord, format)
 
             if tile_data is None:
                 tile_data = self.reformat_from_stored_json(
@@ -338,7 +338,7 @@ class TileServer(object):
                 tile_data = reformat_selected_layers(
                     json_data_all, layer_data, coord, format, self.buffer_cfg)
 
-            self.cache.set(coord, tile_data)
+            self.cache.set(coord, format, tile_data)
 
         response = self.create_response(
             request, 200, tile_data, format.mimetype)

--- a/tileserver/cache.py
+++ b/tileserver/cache.py
@@ -1,0 +1,194 @@
+import errno
+import os
+import time
+from string import zfill
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
+
+def clean_empty_parent_dirs(path, parent_dir=None):
+    """
+    Starting from a file or directory ``path``, recursively delete empty
+    parent directories until a non-empty directory or ``parent_dir``
+    is reached.
+
+    This is like ``os.removedirs()`` but with a specified stop point.
+    """
+    if not os.path.exists(path):
+        return
+
+    if not os.path.isdir(path):
+        path = os.path.dirname(path)
+
+    while True:
+        if parent_dir and path.endswith(parent_dir):
+            return
+
+        try:
+            os.rmdir(path)
+            path = os.path.dirname(path)
+        except OSError:
+            return
+
+
+class LockTimeout(BaseException):
+    pass
+
+
+class RedisCache(object):
+    def __init__(self, redis_client, **kwargs):
+        self.client = redis_client
+        self.timeout = kwargs.get('timeout') or 10
+        self.key_prefix = kwargs.get('key_prefix') or 'tiles'
+
+    def generate_key(self, key_type, coord):
+        return '{}.{}.{}-{}-{}'.format(
+            self.key_prefix,
+            key_type,
+            coord.zoom,
+            coord.column,
+            coord.row,
+        )
+
+    def obtain_lock(self, coord, **kwargs):
+        """
+        Obtains a lock based on the given tile coordinate. By default,
+        it will wait/block ``timeout`` seconds before giving up and throwing
+        a ``LockTimeout`` exception.
+
+        :param coord   The tile Coordinate to lock on.
+        :param expires Any existing lock older than ``expires`` seconds will
+                       be considered invalid.
+        :param timeout If another client has already obtained the lock for this
+                       tile, sleep for a maximum of ``timeout`` seconds before
+                       giving up and throwing a ``LockTimeout`` exception. A
+                       value of 0 means to never wait.
+
+        (https://chris-lamb.co.uk/posts/distributing-locking-python-and-redis)
+
+        """
+        key = self.generate_key('lock', coord)
+        expires = kwargs.get('expires', 60)
+        timeout = kwargs.get('timeout', 10)
+
+        while timeout >= 0:
+            expire_tstamp = time.time() + expires + 1
+
+            if self.client.setnx(key, expires):
+                # We gained the lock
+                return
+
+            current_value = self.client.get(key)
+
+            # We found an expired lock and nobody raced us to replacing it
+            if current_value and float(current_value) < time.time() and \
+               self.client.getset(key, expire_tstamp) == current_value:
+                    return
+
+            timeout -= 1
+            time.sleep(1)
+
+        raise LockTimeout("Timeout whilst waiting for a lock")
+
+    def release_lock(self, coord):
+        key = self.generate_key('lock', coord)
+        self.client.delete(key)
+
+    def set(self, coord, data):
+        key = self.generate_key('data', coord)
+        self.client.set(key, data)
+
+    def get(self, coord):
+        key = self.generate_key('data', coord)
+        return self.client.get(key)
+
+
+class FileCache(object):
+    def __init__(self, file_prefix, **kwargs):
+        self.prefix = file_prefix
+
+    def generate_key(self, key_type, coord):
+        x_fill = zfill(coord.column, 9)
+        y_fill = zfill(coord.row, 9)
+
+        return os.path.join(
+            self.prefix,
+            zfill(coord.zoom, 2),
+            x_fill[0:3],
+            x_fill[3:6],
+            x_fill[6:9],
+            y_fill[0:3],
+            y_fill[3:6],
+            '{}.{}'.format(y_fill[6:9], key_type),
+        )
+
+    def _acquire(self, key):
+        try:
+            with open(key, 'r'):
+                return False
+        except IOError:
+            directory = os.path.dirname(key)
+            mkdir_p(directory)
+            with open(key, 'w'):
+                return True
+
+    def obtain_lock(self, coord, **kwargs):
+        """
+        Obtains a lock based on the given tile coordinate. By default,
+        it will wait/block ``timeout`` seconds before giving up and throwing
+        a ``LockTimeout`` exception.
+
+        :param coord   The tile Coordinate to lock on.
+        :param expires Any existing lock older than ``expires`` seconds will
+                       be considered invalid.
+        :param timeout If another client has already obtained the lock for this
+                       tile, sleep for a maximum of ``timeout`` seconds before
+                       giving up and throwing a ``LockTimeout`` exception. A
+                       value of 0 means to never wait.
+        """
+        key = self.generate_key('lock', coord)
+        expires = kwargs.get('expires', 60)
+        timeout = kwargs.get('timeout', 10)
+
+        while timeout >= 0:
+            expires = time.time() + expires + 1
+
+            if self._acquire(key):
+                # We gained the lock
+                return
+
+            timeout -= 1
+            time.sleep(1)
+
+        raise LockTimeout("Timeout whilst waiting for a lock")
+
+    def release_lock(self, coord):
+        key = self.generate_key('lock', coord)
+        try:
+            os.remove(key)
+        except OSError as e:
+            # errno.ENOENT = no such file or directory
+            if e.errno != errno.ENOENT:
+                # re-raise exception if a different error occurred
+                raise
+
+    def set(self, coord, data):
+        key = self.generate_key('data', coord)
+        directory = os.path.dirname(key)
+        mkdir_p(directory)
+
+        with open(key, 'w') as f:
+            f.write(data)
+
+    def get(self, coord):
+        key = self.generate_key('data', coord)
+        with open(key, 'r') as f:
+            return f.read()


### PR DESCRIPTION
This adds a caching backend to store tiles that are generated during a tileserver request. I'm starting off with a File-based cache and a Redis-based cache. This also supports a locking mechanism so that only one instance of tileserver will work on a particular tile at a time.

What's left:
- [x] Get the code for file and redis-based caches working
- [x] Wire up configuration for the cache backend
- [x] Add caching and locking check to the request path
- [x] Include format in the lock/cache key, too