### PR TITLE
Add keyword arg to MockRedis to fix test.

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -127,7 +127,7 @@ class MockRedis(object):
     def __init__(self):
         self._data = {}
 
-    def set(self, key, data):
+    def set(self, key, data, ex=None):
         self._data[key] = data
 
     def get(self, key):


### PR DESCRIPTION
One test was failing with a complaint about the keyword arg `ex` not being supported. It looks like that might be supported in the real client, but missing from the `MockRedis` that's used in the tests. Adding the arg seems to have made the test happy.