### PR TITLE
Use new data fetcher interface, which allows for grouping.

### DIFF
--- a/tileserver/__init__.py
+++ b/tileserver/__init__.py
@@ -225,7 +225,9 @@ class TileServer(object):
             # landuse).
             unpadded_bounds = coord_to_mercator_bounds(coord)
 
-            source_rows = self.data_fetcher(nominal_zoom, unpadded_bounds)
+            for fetcher, _ in self.data_fetcher.fetch_tiles(dict(coord=coord)):
+                source_rows = fetcher(nominal_zoom, unpadded_bounds)
+
             feature_layers = convert_source_data_to_feature_layers(
                 source_rows, self.layer_config.layer_data, unpadded_bounds,
                 nominal_zoom)


### PR DESCRIPTION
Note that at the moment, the `tileserver` can only connect to a postgres backend. It might not ever make sense for the `tileserver` to download RAWR tiles, but this should make it possible if we ever want to.