### PR TITLE
Require a specific version of tilequeue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ wsgiref==0.1.2
 zope.dottedname==4.1.0
 git+https://github.com/ixc/python-edtf@aad32b8d5cd8848c50fbef92c73697a93cf182ba#edtf
 git+https://github.com/mapzen/mapbox-vector-tile@master#egg=mapbox-vector-tile
-git+https://github.com/mapzen/tilequeue@master#egg=tilequeue
+git+https://github.com/mapzen/tilequeue@v1.8.0#egg=tilequeue


### PR DESCRIPTION
This should **not** be merged through the github UI.

2.8.0 will not run with the latest master of tilequeue. Specifying an exact version avoids this. Because of #119, I am not specifying pypi as a source, because the same issue exists for tilequeue.

This should be merged to a branch for v2.8.x and be part of a v2.8.1 release