### PR TITLE
Add value for max_zoom_with_changes

### DIFF
--- a/tileserver/__init__.py
+++ b/tileserver/__init__.py
@@ -261,6 +261,7 @@ class TileServer(object):
             formatted_tiles, extra_data = format_coord(
                 coord,
                 nominal_zoom,
+                nominal_zoom+1,
                 processed_feature_layers,
                 (format,),
                 unpadded_bounds,


### PR DESCRIPTION
Add value for max_zoom_with_changes parameter in format_coord in tilequeue as latest version of tilequeue requires this parameter. I am not sure whether value of nominal_zoom+1 is correct.